### PR TITLE
build.yml: Add on.workflow_call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/build.yml
       - "build-*.sh"
       - debian7/Dockerfile
+  workflow_call:
 
 jobs:
   build:


### PR DESCRIPTION
Fix the error:
```
error parsing called workflow "./.github/workflows/build.yml": workflow is not reusable as it is missing a `on.workflow_call` trigger
```