### PR TITLE
Miscellaneous version bumps and updates

### DIFF
--- a/build-binutils.sh
+++ b/build-binutils.sh
@@ -3,8 +3,8 @@
 set -e
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
-VERSION=2.38
-SHA256SUM=e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024
+VERSION=2.43.1
+SHA256SUM=13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd
 
 # Build binutils
 wget --no-check-certificate https://ftp.gnu.org/gnu/binutils/binutils-$VERSION.tar.xz
@@ -20,6 +20,7 @@ cd binutils-$VERSION
   --enable-multilib \
   --enable-64-bit-bfd \
   --enable-targets=all \
+  --disable-gprofng \
   --disable-nls
 
 make

--- a/build-gawk.sh
+++ b/build-gawk.sh
@@ -3,8 +3,8 @@
 set -e
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
-VERSION=5.1.1
-SHA256SUM=d87629386e894bbea11a5e00515fc909dc9b7249529dad9e6a3a2c77085f7ea2
+VERSION=5.3.1
+SHA256SUM=694db764812a6236423d4ff40ceb7b6c4c441301b72ad502bb5c27e00cd56f78
 
 # Build gawk
 wget --no-check-certificate https://ftp.gnu.org/gnu/gawk/gawk-$VERSION.tar.xz

--- a/build-gcc.sh
+++ b/build-gcc.sh
@@ -17,7 +17,7 @@ cd gcc-$VERSION
 ./contrib/download_prerequisites
 
 # Disable building documentation
-gcc_cv_prog_makeinfo_modern=no
+export gcc_cv_prog_makeinfo_modern=no
 
 mkdir build
 cd build

--- a/build-make.sh
+++ b/build-make.sh
@@ -3,8 +3,8 @@
 set -e
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
-VERSION=4.3
-SHA256SUM=e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19
+VERSION=4.4.1
+SHA256SUM=dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3
 
 # Build make
 wget --no-check-certificate https://ftp.gnu.org/gnu/make/make-${VERSION}.tar.gz

--- a/build-python3.sh
+++ b/build-python3.sh
@@ -3,8 +3,8 @@
 set -e
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
-VERSION=3.9.13
-SHA256SUM=125b0c598f1e15d2aa65406e83f792df7d171cdf38c16803b149994316a3080f
+VERSION=3.11.10
+SHA256SUM=07a4356e912900e61a15cb0949a06c4a05012e213ecd6b4e84d0f67aabbee372
 
 # Build Python 3
 wget --no-check-certificate https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tar.xz

--- a/build-sed.sh
+++ b/build-sed.sh
@@ -3,8 +3,8 @@
 set -e
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
-VERSION=4.8
-SHA256SUM=f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633
+VERSION=4.9
+SHA256SUM=6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181
 
 # Build sed
 wget --no-check-certificate https://ftp.gnu.org/gnu/sed/sed-$VERSION.tar.xz

--- a/debian7/Dockerfile
+++ b/debian7/Dockerfile
@@ -2,7 +2,8 @@ FROM debian/eol:wheezy
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-  && apt-get install -y build-essential bzip2 libz-dev texinfo wget
+  && apt-get install -y build-essential bzip2 ca-certificates libz-dev texinfo wget \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --shell /bin/bash linuxbrew
 

--- a/utils.sh
+++ b/utils.sh
@@ -3,20 +3,20 @@
 set -e
 
 verify_checksum() {
-  FILE=$1
-  EXPECTED_CHECKSUM=$2
-  FILE_CHECKSUM=$(sha256sum ${FILE} | cut -d ' ' -f 1)
+  FILE="$1"
+  EXPECTED_CHECKSUM="$2"
+  FILE_CHECKSUM="$(sha256sum "${FILE}" | cut -d ' ' -f 1)"
 
-  if [[ $FILE_CHECKSUM != $EXPECTED_CHECKSUM ]]; then
+  if [[ "$FILE_CHECKSUM" != "$EXPECTED_CHECKSUM" ]]; then
     echo "Checksum mismatch!"
     return 1
   fi
 }
 
 package() {
-  PKGNAME=$1
-  VERSION=$2
+  PKGNAME="$1"
+  VERSION="$2"
 
-  cd $PREFIX
-  tar --remove-files --create --gzip --file $PKGDIR/bootstrap-$PKGNAME-$VERSION.tar.gz .
+  tar -C "$PREFIX" -czvf "$PKGDIR/bootstrap-$PKGNAME-$VERSION.tar.gz" .
+  find "$PREFIX" -mindepth 1 -delete
 }

--- a/utils.sh
+++ b/utils.sh
@@ -17,6 +17,8 @@ package() {
   PKGNAME="$1"
   VERSION="$2"
 
-  tar -C "$PREFIX" -czvf "$PKGDIR/bootstrap-$PKGNAME-$VERSION.tar.gz" .
+  tar --directory "$PREFIX" \
+    --create --gzip --verbose \
+    --file "$PKGDIR/bootstrap-$PKGNAME-$VERSION.tar.gz" .
   find "$PREFIX" -mindepth 1 -delete
 }


### PR DESCRIPTION
These are the platform-agnostic changes split from #31, as AArch64 support needs to wait for GA of GitHub-hosted arm64 Linux runners in early 2025.
