### PR TITLE
workflows: use full version numbers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - container: debian7
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
@@ -43,7 +43,7 @@ jobs:
         run: docker cp ${{github.sha}}:/home/linuxbrew/bootstrap-binaries .
 
       - name: Upload binaries to GitHub Actions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: bootstrap-${{matrix.binary}}
           path: bootstrap-binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
       GH_TOKEN: ${{github.token}}
       TAG: ${{github.event.inputs.tag}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
       - name: Download binaries from GitHub Actions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: bootstrap-*
           path: bootstrap-binaries


### PR DESCRIPTION
This helps with transparency and they get updated by Dependabot.