### PR TITLE
Fix issues with aarch64 GCC

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - BrewTestBot

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
       - Dockerfile*
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    env:
-      GH_TOKEN: ${{github.token}}
-      TAG: ${{github.event.inputs.tag}}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -33,8 +30,8 @@ jobs:
           path: bootstrap-binaries
           merge-multiple: true
 
-      - name: Push tag
-        run: gh release create "$TAG" --generate-notes
-
-      - name: Upload to GitHub Releases
-        run: gh release upload "$TAG" bootstrap-binaries/*.tar.gz
+      - name: Create release
+        run: gh release create "$TAG" --generate-notes bootstrap-binaries/*.tar.gz
+        env:
+          GH_TOKEN: ${{github.token}}
+          TAG: ${{github.event.inputs.tag}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
         description: Version to use for release tag
         required: true
 
+permissions: {}
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml

--- a/build-gcc.sh
+++ b/build-gcc.sh
@@ -39,6 +39,7 @@ cd build
   --disable-threads \
   --disable-multilib \
   --enable-multiarch \
+  --enable-standard-branch-protection \
   --with-newlib \
   --without-headers
 make

--- a/build-gcc.sh
+++ b/build-gcc.sh
@@ -38,6 +38,7 @@ cd build
   --disable-libvtv \
   --disable-threads \
   --disable-multilib \
+  --enable-multiarch \
   --with-newlib \
   --without-headers
 make


### PR DESCRIPTION
1.1.1 candidate release

aarch64 fixes:

* Fix portability of aarch64 GCC on Ubuntu runners by always enabling multiarch rather than checking the host. This wasn't an issue on x86_64 since the host there was Debian whereas for aarch64 we're using CentOS here.
  - Note: multiarch is just a search directory thing - the build is still only a single architecture
* Build libgcc with branch protection so that we can build glibc with branch protection

Misc fixes while we're here:

* Fix some code scanning flags
* Combine release steps to allow immutable releases
* Exclude bot spam from release notes