### PR TITLE
build-gcc.sh: auto-detect CET

### DIFF
--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,11 +1,11 @@
 FROM centos:6
 
+# Need newer GCC and GAS (binutils) to build with CET support
 RUN sed -e 's/mirror\.centos\.org/vault\.centos\.org/g' \
         -e 's/^mirrorlist=/#mirrorlist=/g' \
         -e 's/^#\s*baseurl=/baseurl=/g' \
         -i /etc/yum.repos.d/CentOS-*.repo \
   && yum install -y @development bzip2 ca-certificates texinfo wget zlib-devel \
-  # Need newer GCC and GAS (binutils) to build with CET support
   && yum install -y centos-release-scl-rh \
   && sed -e 's/mirror\.centos\.org/vault\.centos\.org/g' \
          -e 's/^mirrorlist=/#mirrorlist=/g' \
@@ -16,7 +16,7 @@ RUN sed -e 's/mirror\.centos\.org/vault\.centos\.org/g' \
 
 RUN useradd --create-home --shell /bin/bash linuxbrew
 
-ENV PATH=/opt/rh/devtoolset-9/root/usr/bin:${PATH}
+ENV BASH_ENV=/opt/rh/devtoolset-9/enable
 ENV CFLAGS="-march=core2 -O2"
 ENV CXXFLAGS="-march=core2 -O2"
 ENV PREFIX=/tmp/homebrew

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,12 +1,22 @@
-FROM debian/eol:wheezy
-ARG DEBIAN_FRONTEND=noninteractive
+FROM centos:6
 
-RUN apt-get update \
-  && apt-get install -y build-essential bzip2 ca-certificates libz-dev texinfo wget \
-  && rm -rf /var/lib/apt/lists/*
+RUN sed -e 's/mirror\.centos\.org/vault\.centos\.org/g' \
+        -e 's/^mirrorlist=/#mirrorlist=/g' \
+        -e 's/^#\s*baseurl=/baseurl=/g' \
+        -i /etc/yum.repos.d/CentOS-*.repo \
+  && yum install -y @development bzip2 ca-certificates texinfo wget zlib-devel \
+  # Need newer GCC and GAS (binutils) to build with CET support
+  && yum install -y centos-release-scl-rh \
+  && sed -e 's/mirror\.centos\.org/vault\.centos\.org/g' \
+         -e 's/^mirrorlist=/#mirrorlist=/g' \
+         -e 's/^#\s*baseurl=/baseurl=/g' \
+         -i /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
+  && yum install -y devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-binutils \
+  && yum clean all
 
 RUN useradd --create-home --shell /bin/bash linuxbrew
 
+ENV PATH=/opt/rh/devtoolset-9/root/usr/bin:${PATH}
 ENV CFLAGS="-march=core2 -O2"
 ENV CXXFLAGS="-march=core2 -O2"
 ENV PREFIX=/tmp/homebrew

--- a/build-gcc.sh
+++ b/build-gcc.sh
@@ -38,6 +38,7 @@ cd build
   --disable-libvtv \
   --disable-threads \
   --disable-multilib \
+  --enable-cet=auto \
   --enable-multiarch \
   --enable-standard-branch-protection \
   --with-newlib \


### PR DESCRIPTION
Exploring CET (Intel's equivalent to ARM PAC/BTI). Most bottles in Homebrew have it enabled due to Ubuntu GCC. However, will likely use permissive mode in glibc to avoid potential Tier 2/3 setups that may end up mixing CET enabled relocatable bottles with source built CET disabled libaries.

Not sure if this is sufficient. Will at least check binaries have CET enabled after CI runs.

`--enable-cet=auto` will be default if we ever need to switch bootstrap to GCC 12+ - https://github.com/gcc-mirror/gcc/commit/9df6c9c7a3936ff0a38a7066281842128cdd6914

---

EDIT: I think GCC >= 8 / Binutils >= 2.30 is needed to build objects with CET.
- https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#-fcf-protection=full

Debian is more complicated to set this up as they don't provide newer toolchains so would need to do a multi-stage build. Or a combined GCC+Binutils tree with bootstrap build may work. Both would take longer on CI.

CentOS provides the RHEL devtoolset which includes newer toolchains. CentOS 6 should use glibc 2.12 allowing compatibility with Debian Wheezy's glibc 2.13.