### PR TITLE
build-python3.sh: remove test modules to reduce size

### DIFF
--- a/build-python3.sh
+++ b/build-python3.sh
@@ -13,7 +13,13 @@ verify_checksum Python-$VERSION.tar.xz $SHA256SUM
 tar --extract --file Python-$VERSION.tar.xz
 cd Python-$VERSION
 
-./configure --prefix="${PREFIX}" ac_cv_search_crypt=no ac_cv_search_crypt_r=no
+./configure \
+  --prefix="${PREFIX}" \
+  --disable-test-modules \
+  --without-ensurepip \
+  --without-static-libpython \
+  ac_cv_search_crypt=no \
+  ac_cv_search_crypt_r=no
 make
 make install
 


### PR DESCRIPTION
Test modules are for self-testing Python so aren't needed by glibc. They account for ~120M of installation which is a third of the total size.

~~The default OPT sets `-g` which adds another 20M of unused debug symbols. We can override this to avoid bloat~~

Also avoid installing libpython.a (~43M) and setting up ensurepip (~23M) which shouldn't be needed to build glibc.

---

glibc is one of packages that may need to be built from source so keeping sizes small indirectly helps with faster install.